### PR TITLE
compression header

### DIFF
--- a/include/kingkong/compression.h
+++ b/include/kingkong/compression.h
@@ -1,3 +1,4 @@
+#ifndef KINGKONG_ENAHLE_COMPRESSION
 #pragma once
 
 #include <string>
@@ -46,3 +47,4 @@ namespace kingkong {
         }
     }
 }
+#endif


### PR DESCRIPTION
@krishpranav you have missed the KINGKONG_ENABLE_COMPRESSION in the header file 
use this compression header file when only enabled it :)

```cmake
if(KINGKONG_ENABLE_COMPRESSION)
  add_executable(example_compression example_compression.cpp)
  add_warnings_optimizations(example_compression)
  target_link_libraries(example_compression Kingkong::Kingkong)
else()
```